### PR TITLE
Changed Hash.update to use HMSET rather than iterating HSET

### DIFF
--- a/trol/collection.py
+++ b/trol/collection.py
@@ -1492,7 +1492,7 @@ class Hash(Collection, collections.MutableMapping):
 
         :rtype: dict
         """
-        return dict([(k, self.deserialize(v)) for (k, v) in self.redis.hgetall(self.key)])
+        return {k: self.deserialize(v) for k, v in self.redis.hgetall(self.key).items()}
 
     def hvals(self):
         """

--- a/trol/collection.py
+++ b/trol/collection.py
@@ -1440,7 +1440,7 @@ class Hash(Collection, collections.MutableMapping):
 
     def _set_dict(self, new_dict):
         self.clear()
-        self.update(new_dict)
+        self.hmset(new_dict)
 
     def hlen(self):
         """Returns the number of elements in the Hash.
@@ -1545,8 +1545,13 @@ class Hash(Collection, collections.MutableMapping):
 
         :param mapping: a dict with keys and values
         """
+        if not mapping:
+            return True
         mapping = {k: self.serialize(v) for k, v in mapping.items()}
         return self.redis.hmset(self.key, mapping)
+
+    def update(self, __m, **kwargs):
+        return self.hmset(dict(__m, **kwargs))
 
     keys = hkeys
     values = hvals

--- a/trol/collection.py
+++ b/trol/collection.py
@@ -1545,7 +1545,7 @@ class Hash(Collection, collections.MutableMapping):
 
         :param mapping: a dict with keys and values
         """
-        mapping = dict([(k, self.serialize(v)) for (k, v) in mapping])
+        mapping = {k: self.serialize(v) for k, v in mapping.items()}
         return self.redis.hmset(self.key, mapping)
 
     keys = hkeys


### PR DESCRIPTION
Also, fixed two bugs in hmset:
1. it was expecting an iterable of pairs, contrary to the documentation and the signature of Redis.hmset
2. It didn't workaround Redis.hmset() rejecting empty maps