### PR TITLE
Fix errors in List

### DIFF
--- a/trol/collection.py
+++ b/trol/collection.py
@@ -822,7 +822,7 @@ class List(Collection):
 
         :param iterable: an iterable objects.
         """
-        self.rpush(*[self.serialize(e) for e in iterable])
+        self.rpush(*iterable)
 
     def count(self, value):
         """

--- a/trol/collection.py
+++ b/trol/collection.py
@@ -784,7 +784,8 @@ class List(Collection):
         Push the value into the list from the *left* side
 
         :param values: a list of values or single value to push
-        :rtype: long representing the number of values pushed.
+        :rtype: long representing the size of the list,
+            unless values is empty, in which case, 0
 
         >>> l = trol.List('test', redis)
         >>> l.lpush(['a', 'b'])
@@ -792,6 +793,8 @@ class List(Collection):
         >>> l.clear()
 
         """
+        if not values:
+            return 0
         values = [self.serialize(v) for v in _parse_values(values)]
         return self.redis.lpush(self.key, *values)
 
@@ -800,7 +803,8 @@ class List(Collection):
         Push the value into the list from the *right* side
 
         :param values: a list of values or single value to push
-        :rtype: long representing the size of the list.
+        :rtype: long representing the size of the list,
+            unless values is empty, in which case, 0
 
         >>> l = trol.List('test', redis)
         >>> l.lpush(['a', 'b'])
@@ -813,6 +817,8 @@ class List(Collection):
 
         """
 
+        if not values:
+            return 0
         values = [self.serialize(v) for v in _parse_values(values)]
         return self.redis.rpush(self.key, *values)
 


### PR DESCRIPTION
- List.extend was serializing twice, causing errors. fixed
- don't error on rpush/lpush empty lists